### PR TITLE
webリンク修正

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,7 +49,7 @@ export default function Home(): JSX.Element {
       description: "JavaとDatabaseを使ったアプリ制作"
     },
     {
-      to: "/beginners/intro",
+      to: "/web-docs/intro",
       imgUrl: useBaseUrl("/img/web.png"),
       title: "Web Development",
       description: "WebサイトやWebアプリ制作"


### PR DESCRIPTION
トップページでのWeb班ドキュメントリンクを選択するとbeginnersドキュメントへ遷移してしまう問題を解決