### PR TITLE
Add support for additional syntax highlighting languages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -299,7 +299,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['csharp'],
+      additionalLanguages: ['csharp', 'java'],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -299,7 +299,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['csharp', 'java'],
+      additionalLanguages: ['csharp', 'java', 'php',`html`,`css`,`javascript`,`git`,`dart`],
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
This pull request adds support for Java, PHP, HTML, CSS, JavaScript, Git, and Dart syntax highlighting in the `docusaurus.config.ts` file. Previously, only C# syntax highlighting was supported. With this change, users will be able to highlight code written in these additional languages in their documentation.