### PR TITLE
Add support for Java, PHP, HTML, CSS, JavaScript, Git, and Dart syntax highlighting

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -299,7 +299,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['csharp', 'java', 'php',`html`,`css`,`javascript`,`git`,`dart`],
+      additionalLanguages: ['csharp', 'java', 'php',`html`,`css`,`javascript`,`git`],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -299,7 +299,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['csharp'],
+      additionalLanguages: ['csharp', 'java'],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -299,7 +299,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['csharp', 'java'],
+      additionalLanguages: ['csharp', 'java', 'php',`html`,`css`,`javascript`,`git`,`dart`],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -299,7 +299,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['csharp', 'java', 'php',`html`,`css`,`javascript`,`git`],
+      additionalLanguages: ['csharp', 'java', `html`,`css`,`javascript`,`git`],
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
This pull request adds support for Java, PHP, HTML, CSS, JavaScript, Git, and Dart syntax highlighting in the `docusaurus.config.ts` file. It includes the following commits:

- "feat: Add support for Java syntax highlighting in docusaurus.config.ts"

- "feat: Add support for PHP, HTML, CSS, JavaScript, Git, and Dart syntax highlighting in docusaurus.config.ts"

- "feat: Remove Dart from additionalLanguages in docusaurus.config.ts"

- "feat: Update additionalLanguages in docusaurus.config.ts"

These changes modify the `additionalLanguages` property in the `prism` configuration object, adding support for the mentioned languages.

なんかサポート外の言語追加しちゃってたらしくエラー出てるのでいったんやばそうなのを削除